### PR TITLE
Fix build issues with recent GNU Radio

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -39,7 +39,8 @@ STD_DEFINES_AND_INCLUDES = \
 	$(DEFINES) \
 	-I$(abs_top_srcdir)/include \
 	-I$(GNURADIO_CORE_INCLUDEDIR) \
-	-I$(GNURADIO_CORE_INCLUDEDIR)/swig
+	-I$(GNURADIO_CORE_INCLUDEDIR)/swig \
+	-I$(GRUEL_INCLUDEDIR)/gruel/swig
 
 # includes
 modincludedir = $(includedir)/$(modname)

--- a/config/gr_standalone.m4
+++ b/config/gr_standalone.m4
@@ -109,6 +109,7 @@ m4_define([GR_STANDALONE],
   AM_CONDITIONAL([HAS_XMLTO], [test x$XMLTO = xyes])
 
   PKG_CHECK_MODULES(GNURADIO_CORE, gnuradio-core >= 3)
+  PKG_CHECK_MODULES(GRUEL, gruel >= 3)
   LIBS="$LIBS $GNURADIO_CORE_LIBS"
 
   dnl Allow user to choose whether to generate SWIG/Python 


### PR DESCRIPTION
Building gr-baz against recent GNU Radio fails because the gruel swig stuff has been relocated from include/gnuradio/swig to include/gruel/swig. This patch will correctly detect and set the gruel include path and should work with both the 3.5 and 3.6 series.
