### PR TITLE
assigned categories to all blocks without any

### DIFF
--- a/grc/baz_agc_xx.xml
+++ b/grc/baz_agc_xx.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>AGC (Baz)</name>
 	<key>baz_agc_xx</key>
+	<category>Level Controllers</category>
 	<import>import baz</import>
 	<make>baz.agc_$(type.fcn)($rate, $reference, $gain, $max_gain)</make>
 	<param>

--- a/grc/baz_delay.xml
+++ b/grc/baz_delay.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Variable Delay</name>
 	<key>baz_delay</key>
+	<category>Misc</category>
 	<import>import baz</import>
 	<make>baz.delay($type.size*$vlen, $delay)</make>
 	<callback>set_delay($delay)</callback>

--- a/grc/baz_message_callback.xml
+++ b/grc/baz_message_callback.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Message Callback</name>
 	<key>baz_message_callback</key>
+	<category>Message Tools</category>
 	<import>from baz import message_callback</import>
 	
 	<make>message_callback.message_callback(msgq=$(id)_msgq_in,#slurp

--- a/grc/baz_message_relay.xml
+++ b/grc/baz_message_relay.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Message Relay</name>
 	<key>baz_message_relay</key>
+	<category>Message Tools</category>
 	<import>from baz import message_relay</import>
 	
 	<make>message_relay.message_relay(tx_msgq=$(id)_msgq_out,rx_msgq=#slurp

--- a/grc/baz_swap_ff.xml
+++ b/grc/baz_swap_ff.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Swap</name>
 	<key>swap_ff</key>
+	<category>Misc</category>
 	<import>import baz</import>
 	<make>baz.swap_ff($swap)</make>
 	<callback>set_swap($swap)</callback>

--- a/grc/baz_tcp_sink.xml
+++ b/grc/baz_tcp_sink.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>TCP Sink (Baz)</name>
 	<key>baz_tcp_sink</key>
+	<category>Networking Tools</category>
 	<import>import baz</import>
 	<make>baz.tcp_sink(
 	itemsize=$type.size*$vlen,

--- a/grc/baz_tcp_source.xml
+++ b/grc/baz_tcp_source.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>TCP Source (Baz)</name>
 	<key>baz_tcp_source</key>
+	<category>Networking Tools</category>
 	<import>import baz</import>
 	<make>baz.tcp_source(
 	itemsize=$type.size*$vlen,

--- a/grc/baz_udp_sink.xml
+++ b/grc/baz_udp_sink.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>UDP Sink (Baz)</name>
 	<key>baz_udp_sink</key>
+	<category>Networking Tools</category>
 	<import>import baz</import>
 	<make>baz.udp_sink($type.size*$vlen, $ipaddr, $port, $psize, $eof, $borip)
 #if $status_in()

--- a/grc/baz_udp_source.xml
+++ b/grc/baz_udp_source.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>UDP Source (Baz)</name>
 	<key>baz_udp_source</key>
+	<category>Networking Tools</category>
 	<import>import baz</import>
 	<make>baz.udp_source($type.size*$vlen, $ipaddr, $port, $psize, $eof, $wait, $borip, $verbose)</make>
 	<callback>set_mtu($mtu)</callback>

--- a/grc/baz_xmlrpc_server.xml
+++ b/grc/baz_xmlrpc_server.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>XMLRPC Server (Baz)</name>
 	<key>baz_xmlrpc_server</key>
+	<category>Misc</category>
 	<import>from baz import introspective_xmlrpc_server</import>
 	<import>import threading</import>
 	<make>introspective_xmlrpc_server.IntrospectiveXMLRPCServer(($addr, $port), allow_none=True, signatures=$sigs)

--- a/grc/gr_mpsk_receiver_debug_cc.xml
+++ b/grc/gr_mpsk_receiver_debug_cc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>MPSK Receiver (Debug)</name>
 	<key>gr_mpsk_receiver_debug_cc</key>
+	<category>Debug Tools</category>
 	<import>from gnuradio import gr</import>
 	<make>gr.mpsk_receiver_cc($M, $theta, $alpha, $beta, $fmin, $fmax, $mu, $gain_mu, $omega, $gain_omega, $omega_relative_limit)</make>
 	<callback>set_alpha($alpha)</callback>


### PR DESCRIPTION
Hello,

in http://lists.gnu.org/archive/html/discuss-gnuradio/2014-12/msg00133.html I was told that it might be appreciated, if I added categories to GRC blocks, which actually have no assigned one. Thus, I submit a pull request, which assignes categories to blocks, which previously had no assigned category.

The change log in detail (pattern: block name -> new category - reason):
* AGC (BAZ) -> Level Controllers - like gr-analog AGCs
* Variable Delay -> Misc - like gr-blocks::delay
* Message Callback	-> Message Tools - like gr-blocks::message_sink
* Message Relay -> Message Tools - like gr-blocks::message_sink
* Swap -> Misc - no better idea
* TCP Sink (Baz) -> Networking Tools - like in-tree-module(gr) of equal name
* TCP Source (Baz) -> Networking Tools - dto.
* UDP Sink (Baz) -> Networking Tools - dto.
* UDP Source (Baz) -> Networking Tools - dto.
* XMLRPC Server (Baz) -> Misc - like in-tree-module(gr) of equal name
* MPSK Receiver (Debug) -> Debug Tools - no better idea

BTW: neither baz_gat.xml nor usrp_simple_source_x.xml are not shown in GRC (I don't know the reason)

/Stephan