### PR TITLE
fractional_resampler: include stdio.h for fprintf().

### DIFF
--- a/lib/baz_fractional_resampler_cc.cc
+++ b/lib/baz_fractional_resampler_cc.cc
@@ -24,6 +24,8 @@
 #include "config.h"
 #endif
 
+#include <stdio.h>
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/filter/mmse_fir_interpolator_cc.h>
 #include "baz_fractional_resampler_cc.h"


### PR DESCRIPTION
GNU Radio update with pybombs failed on my Ubuntu 16.04 system (gcc 5.4.1) with complaints about stderr and fprintf being undeclared in baz_fractional_resampler_cc.cc.

Including stdio fixed it for me.

