### PR TITLE
Compiles with boost 1.67

### DIFF
--- a/lib/baz_burster.cc
+++ b/lib/baz_burster.cc
@@ -222,7 +222,7 @@ fprintf(stderr, "[%s<%li>] updated time\n", name().c_str(), unique_id());
 						if (d_config.sample_interval)
 							limit /= (double)d_config.sample_rate;
 						
-						if (diff >= boost::posix_time::microseconds(limit * 1e6))
+						if (diff >= boost::posix_time::microseconds(static_cast<long>(limit * 1e6)))
 						//if (d >= limit)
 						{
 //fprintf(stderr, "[%s<%i>] host elapsed %f\n", name().c_str(), unique_id(), ((float)diff.ticks() / (float)d_system_time_ticks_per_second));


### PR DESCRIPTION
Fixes https://github.com/balint256/gr-baz/issues/55

Before boost 1.67 values passed to `date_time` structs would be auto-converted from floating point numbers to integers. Boost 1.67 disallows this to force user handling of special values (like NaN).

This converts the interval time back to an integer before being sent to `posix_time::microseconds`.