### PR TITLE
Fix a type error

### DIFF
--- a/lib/baz_burster.cc
+++ b/lib/baz_burster.cc
@@ -222,7 +222,7 @@ fprintf(stderr, "[%s<%li>] updated time\n", name().c_str(), unique_id());
 						if (d_config.sample_interval)
 							limit /= (double)d_config.sample_rate;
 						
-						if (diff >= boost::posix_time::microseconds(limit * 1e6))
+						if (diff >= boost::posix_time::microseconds((long)(limit * 1e6)))
 						//if (d >= limit)
 						{
 //fprintf(stderr, "[%s<%i>] host elapsed %f\n", name().c_str(), unique_id(), ((float)diff.ticks() / (float)d_system_time_ticks_per_second));


### PR DESCRIPTION
Project was not building for me w/ GCC 9.2.0 and Boost 1.71.0. Casting this to a long fixed the problem. I have not tested it at runtime; in particular, I do not know if the number is typically less than 1, or much more than 1 in real usage. (If it is much more than 1, then this patch will be fine, otherwise it may be problematic.)